### PR TITLE
Avoid warnings by using --no-cache-dir with pip

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,7 +14,7 @@ fi
 arrPY_VERSIONS=(${PY_VERSIONS// / })
 for PY_VER in "${arrPY_VERSIONS[@]}"; do
     # Update pip
-    /opt/python/${PY_VER}/bin/pip install --upgrade pip
+    /opt/python/${PY_VER}/bin/pip install --upgrade --no-cache-dir pip
 
     # Check if requirements were passed
     if [ ! -z "$BUILD_REQUIREMENTS" ]; then


### PR DESCRIPTION
This should avoid warnings like:
 WARNING: The directory '/github/home/.cache/pip/http' or its parent directory
 is not owned by the current user and the cache has been disabled. Please check
 the permissions and owner of that directory.

I saw this used by one of the official pypa docker images:
 <https://github.com/pypa/gh-action-pypi-publish/blob/master/Dockerfile>