### PR TITLE
Remove RUN clause from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,5 @@ FROM quay.io/pypa/manylinux2010_x86_64
 ENV PLAT manylinux2010_x86_64
 
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Removed RUN clause from Dockerfile.

Resolves #21.