### PR TITLE
Temporary workaround for LD_LIBRARY_PATH issue (#26)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Setup Python environment
-      uses: actions/setup-python@v1.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Create new tags

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,18 @@ on: [push, pull_request]
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: 3.6
+            pep-425-tag: 'cp36-cp36m'
+          - python-version: 3.7
+            pep-425-tag: 'cp37-cp37m'
+          - python-version: 3.8
+            pep-425-tag: 'cp38-cp38'
+          - python-version: 3.9
+            pep-425-tag: 'cp39-cp39'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout action
@@ -19,11 +31,11 @@ jobs:
     - name: Setup Python environment
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python-version }}
     - name: Build manylinux Python wheels
       uses: './test_action'
       with:
-        python-versions: 'cp38-cp38'
+        python-versions: ${{ matrix.pep-425-tag }}
         build-requirements: 'setuptools numpy cython'
         system-packages: 'lrzip-devel zlib-devel'
         pre-build-command: 'echo Hello world! Testing pre-build command'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,36 +16,10 @@ jobs:
         repository: ralfg/hello_py
         ref: v0.1.0
         path: hello_py
-    - name: Build manylinux Python wheels
-      uses: './test_action'
-      with:
-        python-versions: 'cp38-cp38'
-        build-requirements: 'setuptools numpy cython'
-        system-packages: 'lrzip-devel zlib-devel'
-        pre-build-command: 'echo Hello world! Testing pre-build command'
-        package-path: 'hello_py'
     - name: Setup Python environment
       uses: actions/setup-python@v2
-    - name: Install wheel
-      run: 'pip install hello_py/dist/hello_py*-manylinux*.whl'
-    - name: Test wheel
-      run: 'hello_py'
-
-  test-with-setup-python:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout action
-      uses: actions/checkout@v2
       with:
-        path: test_action
-    - name: Setup Python environment
-      uses: actions/setup-python@v2
-    - name: Checkout hello_py dummy project
-      uses: actions/checkout@v2
-      with:
-        repository: ralfg/hello_py
-        ref: v0.1.0
-        path: hello_py
+        python-version: 3.8
     - name: Build manylinux Python wheels
       uses: './test_action'
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         pre-build-command: 'echo Hello world! Testing pre-build command'
         package-path: 'hello_py'
     - name: Setup Python environment
-      uses: actions/setup-python@v1.1.1
+      uses: actions/setup-python@v2
     - name: Install wheel
       run: 'pip install hello_py/dist/hello_py*-manylinux*.whl'
     - name: Test wheel
@@ -38,7 +38,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         path: test_action
-    - name: Setup Python
+    - name: Setup Python environment
       uses: actions/setup-python@v2
     - name: Checkout hello_py dummy project
       uses: actions/checkout@v2
@@ -54,8 +54,6 @@ jobs:
         system-packages: 'lrzip-devel zlib-devel'
         pre-build-command: 'echo Hello world! Testing pre-build command'
         package-path: 'hello_py'
-    - name: Setup Python environment
-      uses: actions/setup-python@v1.1.1
     - name: Install wheel
       run: 'pip install hello_py/dist/hello_py*-manylinux*.whl'
     - name: Test wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,33 @@ jobs:
       run: 'pip install hello_py/dist/hello_py*-manylinux*.whl'
     - name: Test wheel
       run: 'hello_py'
+
+  test-with-setup-python:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout action
+      uses: actions/checkout@v2
+      with:
+        path: test_action
+    - name: Setup Python
+      uses: actions/setup-python@v2
+    - name: Checkout hello_py dummy project
+      uses: actions/checkout@v2
+      with:
+        repository: ralfg/hello_py
+        ref: v0.1.0
+        path: hello_py
+    - name: Build manylinux Python wheels
+      uses: './test_action'
+      with:
+        python-versions: 'cp38-cp38'
+        build-requirements: 'setuptools numpy cython'
+        system-packages: 'lrzip-devel zlib-devel'
+        pre-build-command: 'echo Hello world! Testing pre-build command'
+        package-path: 'hello_py'
+    - name: Setup Python environment
+      uses: actions/setup-python@v1.1.1
+    - name: Install wheel
+      run: 'pip install hello_py/dist/hello_py*-manylinux*.whl'
+    - name: Test wheel
+      run: 'hello_py'

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ workflow.
 Minimal:
 
 ```yaml
-uses: RalfG/python-wheels-manylinux-build@v0.3.1
+uses: RalfG/python-wheels-manylinux-build@v0.3.2
 with:
   python-versions: 'cp36-cp36m cp37-cp37m'
 ```
@@ -28,7 +28,7 @@ with:
 Using all arguments:
 
 ```yaml
-uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
+uses: RalfG/python-wheels-manylinux-build@v0.3.2-manylinux2010_x86_64
 with:
   python-versions: 'cp36-cp36m cp37-cp37m'
   build-requirements: 'cython numpy'
@@ -63,8 +63,8 @@ wheels are not accepted by PyPI.
 ### Using a different manylinux container
 The `manylinux2010_x86_64` container is used by default. To use another manylinux
 container, append `-<container-name>` to the reference. For example:
-`RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2014_aarch64` instead of
-`RalfG/python-wheels-manylinux-build@v0.3.1`.
+`RalfG/python-wheels-manylinux-build@v0.3.2-manylinux2014_aarch64` instead of
+`RalfG/python-wheels-manylinux-build@v0.3.2`.
 
 ## Contributing
 Bugs, questions or suggestions? Feel free to post an issue in the

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,10 @@ PRE_BUILD_COMMAND=$4
 PACKAGE_PATH=$5
 PIP_WHEEL_ARGS=$6
 
+# Temporary workaround for LD_LIBRARY_PATH issue. See
+# https://github.com/RalfG/python-wheels-manylinux-build/issues/26
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
+
 cd /github/workspace/"${PACKAGE_PATH}"
 
 if [ ! -z "$SYSTEM_PACKAGES" ]; then

--- a/full_workflow_example.yml
+++ b/full_workflow_example.yml
@@ -23,7 +23,7 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Build manylinux Python wheels
-      uses: RalfG/python-wheels-manylinux-build@v0.3.1-manylinux2010_x86_64
+      uses: RalfG/python-wheels-manylinux-build@v0.3.2-manylinux2010_x86_64
       with:
         python-versions: 'cp36-cp36m cp37-cp37m'
         build-requirements: 'cython numpy'


### PR DESCRIPTION
Temporary workaround for LD_LIBRARY_PATH issue (closes #26). Issue was introduced by actions/setup-python#144, Also see actions/setup-python#131. 

This PR also moves the `setup-python` step to before the build step, and extends the action's tests to multiple Python versions.