### PR TITLE
Add PEP 600 manylinux_x_y  containers to Release v0.3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/pypa/manylinux_2_24_ppc64le
+FROM quay.io/pypa/manylinux_2_24_s390x
 
-ENV PLAT manylinux_2_24_ppc64le
+ENV PLAT manylinux_2_24_s390x
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/pypa/manylinux_2_24_x86_64
+FROM quay.io/pypa/manylinux_2_24_i686
 
-ENV PLAT manylinux_2_24_x86_64
+ENV PLAT manylinux_2_24_i686
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/pypa/manylinux_2_24_i686
+FROM quay.io/pypa/manylinux_2_24_aarch64
 
-ENV PLAT manylinux_2_24_i686
+ENV PLAT manylinux_2_24_aarch64
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/pypa/manylinux_2_24_aarch64
+FROM quay.io/pypa/manylinux_2_24_ppc64le
 
-ENV PLAT manylinux_2_24_aarch64
+ENV PLAT manylinux_2_24_ppc64le
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM quay.io/pypa/manylinux2014_s390x
+FROM quay.io/pypa/manylinux_2_24_x86_64
 
-ENV PLAT manylinux2014_s390x
+ENV PLAT manylinux_2_24_x86_64
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This PR adds the following [PEP 600](https://www.python.org/dev/peps/pep-0600/) manylinux_x_y containers to the `rel_v0.3.4` branch:

- [manylinux_2_24_x86_64](https://quay.io/repository/pypa/manylinux_2_24_x86_64)
- [manylinux_2_24_i686](https://quay.io/repository/pypa/manylinux_2_24_i686)
- [manylinux_2_24_aarch64](https://quay.io/repository/pypa/manylinux_2_24_aarch64)
- [manylinux_2_24_ppc64le](https://quay.io/repository/pypa/manylinux_2_24_ppc64le)
- [manylinux_2_24_s390x](https://quay.io/repository/pypa/manylinux_2_24_s390x)

On acceptance, please add to corresponding tags to the repo, so that these version can be used with the action.
Thanks!