### PR TITLE
Use GITHUB_WORKSPACE env variable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ PIP_WHEEL_ARGS=$6
 # https://github.com/RalfG/python-wheels-manylinux-build/issues/26
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
 
-cd /github/workspace/"${PACKAGE_PATH}"
+cd "${GITHUB_WORKSPACE}"/"${PACKAGE_PATH}"
 
 if [ ! -z "$SYSTEM_PACKAGES" ]; then
     if command -v apt-get >/dev/null; then


### PR DESCRIPTION
This PR changes `/github/workspace` to `$GITHUB_WORKSPACE` in `entrypoint.sh`. This seems to be the recommended way as per [the docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#file-systems).

In practice, this fixes a `No such file or directory` error when trying to run this action via [`act`](https://github.com/nektos/act).