### PR TITLE
Add apt-get update

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,7 @@ cd "${GITHUB_WORKSPACE}"/"${PACKAGE_PATH}"
 
 if [ ! -z "$SYSTEM_PACKAGES" ]; then
     if command -v apt-get >/dev/null; then
+        apt-get update
         apt-get install -y ${SYSTEM_PACKAGES}  || { echo "Installing apt package(s) failed."; exit 1; }
     elif command -v yum >/dev/null; then
         yum install -y ${SYSTEM_PACKAGES}  || { echo "Installing yum package(s) failed."; exit 1; }


### PR DESCRIPTION
This trivial change adds an `apt-get update` before the `apt-get install` command. For me, installing the required packages failed otherwise.

P.S. I did not look into whether a similar fix is needed for CentOS/yum, but that's quite possible.