### PR TITLE
Fix default value of PLAT to correspond to used image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/manylinux_2_24_x86_64
 
-ENV PLAT manylinux2010_x86_64
+ENV PLAT manylinux_2_24_x86_64
 
 COPY entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
This change makes PLAT version consistent with the default container used.

For me this change fixes things when trying to use the master version.