### PR TITLE
Add cp311-cp311 to defaults

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
   python-versions:
     description: 'Python versions to target, space-separated'
     required: true
-    default: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310'
+    default: 'cp36-cp36m cp37-cp37m cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311'
   build-requirements:
     description: 'pip packages required at build time, space-separated'
     required: false


### PR DESCRIPTION
[Python 3.11.0rc1 is now released](https://pythoninsider.blogspot.com/2022/08/python-3110rc1-is-now-available.html), which is guaranteed to be ABI compatible with the final release.
`cibuildwheel v2.9.0` has also enabled it by default. See  https://github.com/pypa/cibuildwheel/releases/tag/v2.9.0.

So, I think it's safe to enable this by default.