### PR TITLE
Auditwheel repair fix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 # action.yml
-name: 'Python wheels manylinux build - agates'
-author: '@agates'
+name: 'Python wheels manylinux build'
+author: 'Ralf Gabriels'
 description: 'Build manylinux wheels for a (Cython) Python package'
 inputs:
   python-versions:

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 # action.yml
-name: 'Python wheels manylinux build'
-author: 'Ralf Gabriels'
+name: 'Python wheels manylinux build - agates'
+author: '@agates'
 description: 'Build manylinux wheels for a (Cython) Python package'
 inputs:
   python-versions:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,9 @@ done
 # find -exec does not preserve failed exit codes, so use an output file for failures
 failed_wheels=$PWD/failed-wheels
 rm -f "$failed_wheels"
-find . -type f -iname "*-manylinux*.whl" -exec sh -c "auditwheel repair '{}' -w \$(dirname '{}') --plat '${PLAT}' || { echo 'Repairing wheels failed.'; auditwheel show '{}' >> "$failed_wheels"; }" \;
+find . -type f -iname "*-manylinux*.whl" -exec sh -c "auditwheel repair '{}' -w \$(dirname '{}') --plat '${PLAT}' || { echo 'Repairing wheels failed.'; auditwheel show '{}' &>> "$failed_wheels"; }" \;
+
+sed -i '/This does not look like a platform wheel/d' "$failed_wheels"
 
 if [[ -s "$failed_wheels" ]]; then
     echo "Repairing wheels failed:"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ done
 # find -exec does not preserve failed exit codes, so use an output file for failures
 failed_wheels=$PWD/failed-wheels
 rm -f "$failed_wheels"
-find . -type f -iname "*-manylinux*.whl" -exec sh -c "auditwheel repair '{}' -w \$(dirname '{}') --plat '${PLAT}' || { echo 'Repairing wheels failed.'; auditwheel show '{}' &>> "$failed_wheels"; }" \;
+find . -type f -iregex ".*-[manylinux|linux].*\.whl" -exec sh -c "auditwheel repair '{}' -w \$(dirname '{}') --plat '${PLAT}' || { echo 'Repairing wheels failed.'; auditwheel show '{}' &>> "$failed_wheels"; }" \;
 
 if [[ -f "$failed_wheels" ]]; then
     sed -i '/This does not look like a platform wheel/d' "$failed_wheels"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,9 @@ failed_wheels=$PWD/failed-wheels
 rm -f "$failed_wheels"
 find . -type f -iname "*-manylinux*.whl" -exec sh -c "auditwheel repair '{}' -w \$(dirname '{}') --plat '${PLAT}' || { echo 'Repairing wheels failed.'; auditwheel show '{}' &>> "$failed_wheels"; }" \;
 
-sed -i '/This does not look like a platform wheel/d' "$failed_wheels"
+if [[ -f "$failed_wheels" ]]; then
+    sed -i '/This does not look like a platform wheel/d' "$failed_wheels"
+fi
 
 if [[ -s "$failed_wheels" ]]; then
     echo "Repairing wheels failed:"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,7 +51,7 @@ failed_wheels=$PWD/failed-wheels
 rm -f "$failed_wheels"
 find . -type f -iname "*-manylinux*.whl" -exec sh -c "auditwheel repair '{}' -w \$(dirname '{}') --plat '${PLAT}' || { echo 'Repairing wheels failed.'; auditwheel show '{}' >> "$failed_wheels"; }" \;
 
-if [[ -f "$failed_wheels" ]]; then
+if [[ -s "$failed_wheels" ]]; then
     echo "Repairing wheels failed:"
     cat failed-wheels
     exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ done
 # find -exec does not preserve failed exit codes, so use an output file for failures
 failed_wheels=$PWD/failed-wheels
 rm -f "$failed_wheels"
-find . -type f -iname "*-linux*.whl" -exec sh -c "auditwheel repair '{}' -w \$(dirname '{}') --plat '${PLAT}' || { echo 'Repairing wheels failed.'; auditwheel show '{}' >> "$failed_wheels"; }" \;
+find . -type f -iname "*-manylinux*.whl" -exec sh -c "auditwheel repair '{}' -w \$(dirname '{}') --plat '${PLAT}' || { echo 'Repairing wheels failed.'; auditwheel show '{}' >> "$failed_wheels"; }" \;
 
 if [[ -f "$failed_wheels" ]]; then
     echo "Repairing wheels failed:"


### PR DESCRIPTION
This does 4 things:
- Fixes the name of the .whl files to look for in the find command for `auditwheel repair` from `"*-linux*.whl"` to `"*-manylinux*.whl"`
- Makes `auditwheel show` stderr output to the `$failed_wheels` file
- Ignores non-breaking "error" `This does not look like a platform wheel` when run against pure python wheels, which can be created, for example, under pypy when the build process doesn't produce compiled code
- Checks if the `$failed_wheels` file is not empty instead of whether it exists before exiting with an error